### PR TITLE
Enable asyncio to get the event loop in a thread other than the main thread

### DIFF
--- a/rocks/ssodnet.py
+++ b/rocks/ssodnet.py
@@ -12,7 +12,7 @@ from rich.progress import Progress
 
 from rocks import config
 from rocks.logging import logger
-
+from rocks.resolve import get_or_create_eventloop
 
 def get_ssocard(id_ssodnet, progress=False, local=True):
     """Retrieve the ssoCard of one or many asteroids, using their SsODNet IDs.
@@ -57,13 +57,13 @@ def get_ssocard(id_ssodnet, progress=False, local=True):
     if not progress:
         # Launching the progressbar in jupyter notebooks spams empty
         # lines, so I'm not using the 'disable' argument of the Progress class
-        loop = asyncio.get_event_loop()
+        loop = get_or_create_eventloop()
         cards = loop.run_until_complete(_get_ssocard(id_ssodnet, None, None, local))
 
     else:
         with Progress() as progress_bar:
             progress = progress_bar.add_task("Getting ssoCards", total=len(id_ssodnet))
-            loop = asyncio.get_event_loop()
+            loop = get_or_create_eventloop()
             cards = loop.run_until_complete(
                 _get_ssocard(id_ssodnet, progress_bar, progress, local)
             )
@@ -260,7 +260,7 @@ def get_datacloud_catalogue(id_ssodnet, catalogue, progress=False, local=True):
     id_catalogue = list(product(id_ssodnet, catalogue))
 
     if not progress:
-        loop = asyncio.get_event_loop()
+        loop = get_or_create_eventloop()
         catalogues = loop.run_until_complete(
             _get_datacloud_catalogue(id_catalogue, None, None, local)
         )[0]
@@ -274,7 +274,7 @@ def get_datacloud_catalogue(id_ssodnet, catalogue, progress=False, local=True):
             )
 
             # Run async loop to get ssoCard
-            loop = asyncio.get_event_loop()
+            loop = get_or_create_eventloop()
             catalogues = loop.run_until_complete(
                 _get_datacloud_catalogue(id_catalogue, progress_bar, progress, local)
             )[0]


### PR DESCRIPTION
`asyncio` only generates an event loop for the main thread, which is a problem for multithreaded app using `rocks`. This PR uses a small trick to get the event loop in a thread other than the main thread. I tested it locally and it worked for my purpose without affecting the other functionalities (as far as I can tell).