### PR TITLE
Move _ensure_index_exists() call outside of init

### DIFF
--- a/rocks/__init__.py
+++ b/rocks/__init__.py
@@ -20,9 +20,3 @@ if context is None or "rocks.cli" not in context[0]:
 
     # Alias id to identify
     id = identify
-
-# Ensure the asteroid name-number index exists
-if not config.PATH_INDEX.is_dir():
-    from . import index
-
-    index._ensure_index_exists()

--- a/rocks/cli.py
+++ b/rocks/cli.py
@@ -156,6 +156,8 @@ def status(clear, update):
 
     from rocks import cache
 
+    index._ensure_index_exists()
+
     # ------
     # Echo inventory
     cached_cards, cached_catalogues = cache.take_inventory()

--- a/rocks/index.py
+++ b/rocks/index.py
@@ -388,6 +388,8 @@ def _get_index_file(id_: typing.Union[int, str]) -> dict:
 @lru_cache(None)
 def _load(which):
     """Load a pickled index file."""
+    _ensure_index_exists()
+
     if not (config.PATH_INDEX / which).exists():
         logger.error(
             "The asteroid name-number index is malformed. Run '$ rocks status' to update it."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from rocks import index
+
+@pytest.fixture(autouse=True, scope='session')
+def ensure_index_exists(request):
+    # Work around https://github.com/pytest-dev/pytest/issues/2704 to avoid capturing output:
+    with request.config.pluginmanager.getplugin('capturemanager').global_and_fixture_disabled():
+        index._ensure_index_exists()


### PR DESCRIPTION
I noticed that as soon as `import rocks` is called, the index is populated if the cache doesn't exist. This can cause delays or crashes in an ephemeral build environment if, say, you want to test a program that imports `rocks` but don't want to test the end-to-end functionality of `rocks` itself.

I moved the index building to the places where it seemed like they first get used, but I'm not super familiar with the code.