### PR TITLE
Add MOID and source region attributes to documentation

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -71,6 +71,10 @@ that ssoCard parameters are accessed via singular-case attribute names while the
 +---------------------------------------------+-----------------------------------------------+
 | parameters.dynamical.tisserand_parameter    |  ``tisserand_parameter``                      |
 +---------------------------------------------+-----------------------------------------------+
+| parameters.dynamical.moid                   |  ``moid``                                     |
++---------------------------------------------+-----------------------------------------------+
+| parameters.dynamical.source_regions         |  ``source_regions``                           |
++---------------------------------------------+-----------------------------------------------+
 | parameters.dynamical.yarkovsky              |  ``yarkovsky``                                |
 +---------------------------------------------+-----------------------------------------------+
 |                                             |                                               |


### PR DESCRIPTION
Hi Max,

I noticed that the MOID and source region fields were missing from the appendix in the documentation. Here's a quick commit (hopefully correct) to add them in.