### PR TITLE
Display shortbib field in colors datacloud

### DIFF
--- a/rocks/config.py
+++ b/rocks/config.py
@@ -145,6 +145,7 @@ DATACLOUD = {
             "phot_sys",
             "observer",
             "delta_time",
+            "shortbib",
         ],
     },
     "densities": {


### PR DESCRIPTION
Hi Max,

As mentioned in EPSC, I would like to have the shortbib field included when printing out the colors datacloud, as is done for other dataclouds (e.g. `rocks colors Ceres`)
This turned out to be pretty trivial to implement, and I think this one-liner is the correct way to do it. Works on my end!
